### PR TITLE
Added Two Trinkets to TWW (Mad Queens Mandate & Ovinax Mercurial Egg)…

### DIFF
--- a/src/CHANGELOG.tsx
+++ b/src/CHANGELOG.tsx
@@ -33,12 +33,14 @@ import {
   ZiayaKens,
   Zyer,
   Gazh,
+  Yellot
 } from 'CONTRIBUTORS';
 import { ItemLink } from 'interface';
 import SpellLink from 'interface/SpellLink';
 
 // prettier-ignore
 export default [
+  change(date(2024, 11, 9), `Added Ovinax Egg and Mad Queens Mandate - Trinkets & Spells`, Yellot),
   change(date(2024, 10, 28), `Updated annotation list rendering for the annotation debugger`, Rzial),
   change(date(2024, 10, 14), `Fixed some technical issues with rendering of lists`, nullDozzer),
   change(date(2024, 10, 12), `Fixed an issue with the effective healing/damage patch causing the per-second damage and healing graphs to be incorrect and causing some by-ability healing and damage numbers to be too low`, Sref),

--- a/src/CONTRIBUTORS.ts
+++ b/src/CONTRIBUTORS.ts
@@ -2533,3 +2533,15 @@ export const Rzial: Contributor = {
   nickname: 'Rzial',
   github: 'Rzial',
 };
+
+export const Yellot: Contributor = {
+  nickname: 'Yellot',
+  github: 'mcheung7272',
+  mains: [
+    {
+      name: 'Yellot',
+      spec: SPECS.MARKSMANSHIP_HUNTER,
+      link: 'https://prod.worldofwarcraft.blizzard.com/en-us/character/us/area-52/yellot',
+    },
+  ],
+};

--- a/src/common/ITEMS/thewarwithin/trinkets.ts
+++ b/src/common/ITEMS/thewarwithin/trinkets.ts
@@ -26,6 +26,16 @@ const trinkets = {
     name: 'Treacherous Transmitter',
     icon: 'inv_etherealraid_communicator_color1',
   },
+  OVINAXS_MERCURIAL_EGG: {
+    id: 220305,
+    name: "Ovi'nax's Mercurial Egg",
+    icon: 'Inv_raid_mercurialegg_purple',
+  },
+  MAD_QUEENS_MANDATE: {
+    id: 212454,
+    name: "Mad Queen's Mandate",
+    icon: 'Inv_raid_abyssaleffigy_purple',
+  },
 } satisfies Record<string, Item>;
 
 export default trinkets;

--- a/src/common/SPELLS/thewarwithin/trinkets.ts
+++ b/src/common/SPELLS/thewarwithin/trinkets.ts
@@ -29,6 +29,18 @@ const spells = {
     name: 'Cryptic Instructions',
     icon: 'inv_etherealraid_communicator_color1',
   },
+  // Ovinax Mercurial Egg
+  SUSPENDED_INCUBATION: {
+    id: 445560,
+    name: 'Suspended Incubation',
+    icon: 'inv_raid_mercurialegg_purple',
+  },
+  //Mad Queen's Mandate
+  ABYSSAL_GLUTTONY: {
+    id: 443124,
+    name: 'Abyssal Gluttony',
+    icon: 'Ability_creature_poison_01_purple',
+  },
 } satisfies Record<string, Spell>;
 
 export default spells;

--- a/src/parser/retail/modules/items/thewarwithin/trinkets/MadQueensMandate.ts
+++ b/src/parser/retail/modules/items/thewarwithin/trinkets/MadQueensMandate.ts
@@ -1,0 +1,37 @@
+import ITEMS from 'common/ITEMS/thewarwithin/trinkets';
+import SPELLS from 'common/SPELLS/thewarwithin/trinkets';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import Events, { DamageEvent } from 'parser/core/Events';
+import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
+import Abilities from 'parser/core/modules/Abilities';
+import SpellUsable from 'parser/shared/modules/SpellUsable';
+
+export default class MadQueensMandate extends Analyzer.withDependencies({
+  abilities: Abilities,
+  spellUsable: SpellUsable,
+}) {
+  protected spellUsable!: SpellUsable;
+
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.MAD_QUEENS_MANDATE.id);
+    if (!this.active) {
+      return;
+    }
+
+    this.deps.abilities.add({
+      spell: SPELLS.ABYSSAL_GLUTTONY.id,
+      category: SPELL_CATEGORY.COOLDOWNS,
+      cooldown: 120,
+    });
+
+    this.addEventListener(Events.damage.spell(SPELLS.ABYSSAL_GLUTTONY), this.onDamage);
+  }
+
+  private onDamage(event: DamageEvent) {
+    if (event.overkill && event.overkill > 0) {
+      this.spellUsable.reduceCooldown(SPELLS.ABYSSAL_GLUTTONY.id, 60000);
+    }
+  }
+}

--- a/src/parser/retail/modules/items/thewarwithin/trinkets/OvinaxMercurialEgg.ts
+++ b/src/parser/retail/modules/items/thewarwithin/trinkets/OvinaxMercurialEgg.ts
@@ -1,0 +1,24 @@
+import ITEMS from 'common/ITEMS/thewarwithin/trinkets';
+import SPELLS from 'common/SPELLS/thewarwithin/trinkets';
+import Analyzer, { Options } from 'parser/core/Analyzer';
+import SPELL_CATEGORY from 'parser/core/SPELL_CATEGORY';
+import Abilities from 'parser/core/modules/Abilities';
+
+export default class OvinaxMercurialEgg extends Analyzer.withDependencies({
+  abilities: Abilities,
+}) {
+  constructor(options: Options) {
+    super(options);
+
+    this.active = this.selectedCombatant.hasTrinket(ITEMS.OVINAXS_MERCURIAL_EGG.id);
+    if (!this.active) {
+      return;
+    }
+
+    this.deps.abilities.add({
+      spell: SPELLS.SUSPENDED_INCUBATION.id,
+      category: SPELL_CATEGORY.COOLDOWNS,
+      cooldown: 120,
+    });
+  }
+}


### PR DESCRIPTION
… (#7174)

* add both mercurial egg and mad queens mandate.

also added their corresponding spell

* added corresponding analyzer trinket files

* added contributor and changelog

* added logic to reduce cd on kill for queens mandate

* fixed cd value

---------

### Description

<!-- A brief description of the changes made with this pull request.-->

### Testing

<!-- How can the reviewer test your changes (if applicable)? -->

- Test report URL: `/report/...`
- Screenshot(s):
